### PR TITLE
readme: update a couple method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ collector.retire(ptr, |_| {});
 println!("{}", (*ptr).value); // <===== unsound!
 ```
 
-Retirement can be delayed until the guard is dropped by calling `reclaim` on
+Retirement can be delayed until the guard is dropped by calling `retire` on
 the guard, instead of on the collector directly:
 
 ```rust,ignore
@@ -264,7 +264,7 @@ losing any information. To extract the underlying value from a link, you can
 call the `cast` method.
 
 ```rust,ignore
-collector.reclaim(value, |link: Link| unsafe {
+collector.retire(value, |link: Link| unsafe {
     // SAFETY: the value passed to reclaim was of type
     // `*mut Linked<Value>`
     let ptr: *mut Linked<Value> = link.cast::<Value>();

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ call the `cast` method.
 
 ```rust,ignore
 collector.retire(value, |link: Link| unsafe {
-    // SAFETY: the value passed to reclaim was of type
+    // SAFETY: the value passed to retire was of type
     // `*mut Linked<Value>`
     let ptr: *mut Linked<Value> = link.cast::<Value>();
 


### PR DESCRIPTION
Updates readme to use `retire` rather than `reclaim` when it meant to refer to the methods `Collector::retire` and `Guard::retire`.