### PR TITLE
Add Support For Dynamically Sized Types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: cargo miri test
         run: cargo miri test
         env:
-          MIRIFLAGS: "-Zmiri-tag-raw-pointers -Zmiri-disable-isolation"
+          MIRIFLAGS: "-Zmiri-disable-isolation"
           
   doc:
     name: Docs

--- a/benches/single_thread.rs
+++ b/benches/single_thread.rs
@@ -48,7 +48,7 @@ criterion_main!(benches);
 
 mod seize_stack {
     use criterion::black_box;
-    use seize::{Collector, Linked};
+    use seize::{Collector, Link, Linked};
     use std::ptr;
 
     pub struct Stack {
@@ -94,8 +94,8 @@ mod seize_stack {
 
                 self.head = (*head).next;
 
-                guard.defer_retire(head, |mut link| {
-                    let head = link.cast::<Node>();
+                guard.defer_retire(head, |link| {
+                    let head: *mut Linked<Node> = Link::cast(link);
                     assert!(!head.is_null());
                     assert!((*head).data == Some(1));
                 });

--- a/benches/stack.rs
+++ b/benches/stack.rs
@@ -135,7 +135,8 @@ mod seize_stack {
                 {
                     unsafe {
                         let data = ptr::read(&(*head).data);
-                        self.collector.retire(head, reclaim::boxed::<Node<T>>);
+                        self.collector
+                            .retire(head, reclaim::boxed::<Linked<Node<T>>>);
                         return Some(ManuallyDrop::into_inner(data));
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,4 @@ mod utils;
 
 pub mod reclaim;
 
-pub use collector::{Collector, Guard, Link, Linked, AsLink};
+pub use collector::{AsLink, Collector, Guard, Link, Linked};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,4 @@ mod utils;
 
 pub mod reclaim;
 
-pub use collector::{AtomicPtr, Collector, Guard, Link, Linked};
+pub use collector::{Collector, Guard, Link, Linked, AsLink};

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -1,12 +1,12 @@
 //! Common memory reclaimers.
 //!
 //! Functions in this module can be passed to [`retire`](crate::Collector::retire)
-//! to free allocated memory or run drop glue. See [the guide](crate#3-reclaimers)
+//! to free allocated memory or run drop glue. See [the guide](crate#custom-reclaimers)
 //! for details about memory reclamation, and writing custom reclaimers.
 
 use std::ptr;
 
-use crate::Link;
+use crate::{AsLink, Link};
 
 /// Reclaims memory allocated with [`Box`].
 ///
@@ -15,12 +15,12 @@ use crate::Link;
 /// # Safety
 ///
 /// Ensure that the correct type annotations are used when
-/// passing this function to [`retire`](crate::Collector::retire):
-/// the link passed must have been created from a **valid**
-/// `Linked<T>`.
-pub unsafe fn boxed<T>(mut link: Link) {
+/// passing this function to [`retire`](crate::Collector::retire).
+/// The value retired must have been of type `T` to be retired through
+/// `boxed::<T>`.
+pub unsafe fn boxed<T: AsLink>(link: *mut Link) {
     unsafe {
-        let _ = Box::from_raw(link.cast::<T>());
+        let _: Box<T> = Box::from_raw(Link::cast(link));
     }
 }
 
@@ -31,11 +31,11 @@ pub unsafe fn boxed<T>(mut link: Link) {
 /// # Safety
 ///
 /// Ensure that the correct type annotations are used when
-/// passing this function to [`retire`](crate::Collector::retire):
-/// the link passed must have been created from a **valid**
-/// `Linked<T>`.
-pub unsafe fn in_place<T>(mut link: Link) {
+/// passing this function to [`retire`](crate::Collector::retire).
+/// The value retired must have been of type `T` to be retired through
+/// `in_place::<T>`.
+pub unsafe fn in_place<T: AsLink>(link: *mut Link) {
     unsafe {
-        ptr::drop_in_place(link.cast::<T>());
+        ptr::drop_in_place::<T>(Link::cast(link));
     }
 }


### PR DESCRIPTION
This PR adds support for dynamically sized types by allowing links to be embedded directly instead of strictly through a `Linked` wrapper. Note that after this change, any generics are no longer implicitly wrapped in `Linked<T>`. For example, any instances of `retire(ptr, reclaim::boxed::<T>)` must be changed to `retire(ptr, reclaim::boxed::<Linked<T>>)`. Fortunately, because of the new `AsLink` bounds, the previous example will result in a compiler error. However, any calls to `link.cast()` (previously calling `Link::cast`) will be silently converted to `ptr.cast()`, and need to be updated to account for the `Linked` wrapper.

Closes https://github.com/ibraheemdev/seize/issues/8.