### PR TITLE
Reduce per-node memory usage

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -29,11 +29,7 @@ impl Collector {
             .unwrap_or(1);
 
         Self {
-            raw: raw::Collector::with_threads(
-                cpus,
-                Self::DEFAULT_EPOCH_TICK,
-                Self::DEFAULT_RETIRE_TICK,
-            ),
+            raw: raw::Collector::new(cpus, Self::DEFAULT_EPOCH_TICK, Self::DEFAULT_RETIRE_TICK),
             unique: Box::into_raw(Box::new(0)),
         }
     }

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -251,7 +251,6 @@ mod tests {
     use super::*;
 
     use std::cell::RefCell;
-    use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering::Relaxed;
     use std::sync::Arc;
     use std::thread;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,7 +32,13 @@
 )]
 #[derive(Default)]
 pub struct CachePadded<T> {
-    value: T,
+    pub value: T,
+}
+
+impl<T> CachePadded<T> {
+    pub fn new(value: T) -> Self {
+        Self { value }
+    }
 }
 
 impl<T> std::ops::Deref for CachePadded<T> {


### PR DESCRIPTION
Move batch data into a single batch allocation. This reduces the size of a node by half, requiring two words instead of four. When epoch tracking is disabled, it would be possible to cut this to a single word by moving linking reservation nodes through the batch, but specializing on that case would require API changes that are avoided for now.

Addresses https://github.com/ibraheemdev/seize/issues/5, https://github.com/jonhoo/flurry/issues/115.