### PR TITLE
Remove `Thread` from public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,3 @@ mod utils;
 pub mod reclaim;
 
 pub use collector::{AsLink, Collector, Guard, Link, Linked};
-pub use tls::Thread;


### PR DESCRIPTION
Addresses https://github.com/ibraheemdev/seize/issues/22. This is technically a breaking change, but is unlikely to cause any issues.