### PR TITLE
Support `Send` and `Sync` Guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 Fast, efficient, and robust memory reclamation for concurrent data structures.
 
-# Introduction
+See the [quick-start guide] to get started.
+
+# Background
 
 Concurrent data structures are faced with the problem of deciding when it is
 safe to free memory. Although an object might have been logically removed, other
@@ -26,7 +28,7 @@ parallelism is degraded when only a fraction of threads are writing. This is
 especially prevalent with the use of M:N threading models as provided by
 asynchronous runtimes like [Tokio].
 
-# Details
+# Implementation
 
 Seize is based on the [hyaline reclamation scheme], which uses reference counting
 to determine when it is safe to free memory. However, reference counters are only
@@ -41,249 +43,10 @@ truly lock-free.
 Seize is compatible with all modern hardware that supports single-word atomic
 operations such as FAA and CAS.
 
-# Guide
-
-Seize tries to stay out of your way as much as possible. It works with raw
-pointers directly instead of creating safe wrapper types that end up being a
-hassle to work with in practice. Below is a step-by-step guide on how to get
-started.
-
-### Collectors
-
-Seize avoids the use of global state and encourages creating a designated
-_collector_ per data structure. Collectors allow you to allocate, protect, and
-retire objects:
-
-```rust,ignore
-use seize::Collector;
-
-struct Stack<T> {
-    collector: Collector,
-    // ...
-}
-
-impl<T> Stack<T> {
-    pub fn new() -> Self {
-        Self {
-            collector: Collector::new(),
-        }
-    }
-}
-```
-
-### Allocating Objects
-
-Seize requires storing some metadata about the global epoch for each object that
-is allocated. It also needs to reserve a couple words for retirement lists.
-Because of this, objects in a concurrent data structure that may be reclaimed must
-embed the `Link` type or use the `Linked<T>` wrapper provided for convenience. See
-[DST Support](#dst-support) for more details.
-
-You can create a `Link` with the `link` method, or allocate and link a value with
-the `link_boxed` helper:
-
-```rust
-use seize::{reclaim, Collector, Linked};
-use std::mem::ManuallyDrop;
-use std::sync::atomic::{AtomicPtr, Ordering};
-
-pub struct Stack<T> {
-    head: AtomicPtr<Linked<Node<T>>>, // <===
-    collector: Collector,
-}
-
-struct Node<T> {
-    next: *mut Linked<Node<T>>, // <===
-    value: ManuallyDrop<T>,
-}
-
-impl<T> Stack<T> {
-    pub fn push(&self, value: T) {
-        let node = self.collector.link_boxed(Node { // <===
-            next: std::ptr::null_mut(),
-            value: ManuallyDrop::new(value),
-        });
-
-        // ...
-    }
-}
-```
-
-### Starting Operations
-
-Before starting an operation that involves loading atomic pointers, you must
-mark the thread as _active_ by calling the `enter` method.
-
-```rust,ignore
-impl Stack {
-    pub fn push(&self, value: T) {
-        // ...
-
-        let guard = self.collector.enter(); // <===
-
-        // ...
-    }
-}
-```
-
-### Protecting Pointers
-
-`enter` returns a guard that allows you to safely load atomic pointers. Any
-valid pointer loaded through a guard is guaranteed to stay valid until the
-guard is dropped, or is retired by the current thread. Importantly, if another
-thread retires an object that you protected, the collector knows not to reclaim
-the object until your guard is dropped.
-
-```rust,ignore
-impl Stack {
-    pub fn push(&self, value: T) {
-        // ...
-
-        let guard = self.collector.enter();
-
-        loop {
-            let head = guard.protect(&self.head, Ordering::Acquire); // <===
-            unsafe { (*node).next = head; }
-
-            if self
-                .head
-                .compare_exchange(head, node, Ordering::Release, Ordering::Relaxed)
-                .is_ok()
-            {
-                break;
-            }
-        }
-
-        // drop(guard);
-    }
-}
-```
-
-Note that the lifetime of a guarded pointer is logically tied to that of the
-guard -- when the guard is dropped the pointer is invalidated -- but a raw
-pointer is returned for convenience. Datastructures that return shared references
-to values should ensure that the lifetime of the reference is tied to the lifetime
-of a guard.
-
-### Retiring Objects
-
-Objects that have been removed from a data structure can be safely _retired_
-through the collector. It will be _reclaimed_ when no threads holds a reference
-to it:
-
-```rust,ignore
-impl<T> Stack<T> {
-    pub fn pop(&self) -> Option<T> {
-        let guard = self.collector.enter(); // <=== mark the thread as active
-
-        loop {
-            let head = guard.protect(&self.head, Ordering::Acquire); // <=== safely load the head
-
-            if head.is_null() {
-                return None;
-            }
-
-            let next = unsafe { (*head).next };
-
-            if self
-                .head
-                .compare_exchange(head, next, Ordering::Release, Ordering::Relaxed)
-                .is_ok()
-            {
-                unsafe {
-                    let data = ptr::read(&(*head).value);
-                    self.collector.retire(head, reclaim::boxed::<Linked<Node<T>>>); // <===
-                    return Some(ManuallyDrop::into_inner(data));
-                }
-            }
-        }
-    }
-}
-```
-
-There are a couple important things to note about retiring an object:
-
-#### Retired objects must be logically removed
-
-An object can only be retired if it is _no longer accessible_ to any thread that
-comes after. In the above code example this was ensured by swapping out the node
-before retiring it. Threads that loaded a value _before_ it was retired are
-safe, but threads that come after are not.
-
-#### Retired objects cannot be accessed by the current thread
-
-Unlike in schemes like EBR, a guard does not protect objects retired by the
-current thread. If no other thread holds a reference to an object it may be
-reclaimed _immediately_. This makes the following code unsound:
-
-```rust,ignore
-let ptr = guard.protect(&node, Ordering::Acquire);
-collector.retire(ptr, |_| {});
-println!("{}", (*ptr).value); // <===== unsound!
-```
-
-Retirement can be delayed until the guard is dropped by calling `defer_retire` on
-the guard, instead of on the collector directly:
-
-```rust,ignore
-let ptr = guard.protect(&node, Ordering::Acquire);
-guard.defer_retire(ptr, |_| {});
-println!("{}", (*ptr).value); // <===== ok!
-drop(guard); // <===== ptr is invalidated
-```
-
-#### Custom Reclaimers
-
-You probably noticed that `retire` takes a function as a second parameter. This
-function is known as a _reclaimer_, and is run when the collector decides it is
-safe to free the retired object. Typically you will pass in a function from the
-[`seize::reclaim`](https://docs.rs/seize/latest/seize/reclaim/index.html) module.
-For example, values allocated with `Box` can use `reclaim::boxed`:
-
-```rust,ignore
-use seize::reclaim;
-
-impl<T> Stack<T> {
-    pub fn pop(&self) -> Option<T> {
-        // ...
-        self.collector.retire(head, reclaim::boxed::<Linked<Node<T>>); // <===
-        // ...
-    }
-}
-```
-
-The type annotation there is important. It is **unsound** to pass a reclaimer of
-a different type than the object being retired.
-
-If you need to run custom reclamation code, you can write a custom reclaimer.
-Functions passed to `retire` are called with a type-erased `Link` pointer. This is
-because retired values are connected to thread-local batches via linked lists,
-losing any type information. To extract the underlying value from a link, you can
-call the `cast` method:
-
-```rust,ignore
-collector.retire(value, |link: *mut Link| unsafe {
-    // SAFETY: the value retired was of type *mut Linked<T>
-    let ptr: *mut Linked<T> = Link::cast(link);
-
-    // SAFETY: the value was allocated with `link_boxed`
-    let value = Box::from_raw(ptr);
-    println!("dropping {}", value);
-    drop(value);
-});
-```
-
-### DST Support
-
-Most reclamation use cases can work with `Linked<T>` and avoid working with
-links directly. However, advanced use cases such as dynamically sized types
-may requie more control over type layout. To support this, seize allows embedding
-a `Link` directly in your type. See the [`AsLink`](https://docs.rs/seize/latest/seize/trait.AsLink.html)
-trait for more details.
-
+[quick-start guide]: https://docs.rs/seize/latest/seize/guide/index.html
+[tokio]: https://github.com/tokio-rs/tokio
 [hazard pointers]:
   https://www.cs.otago.ac.nz/cosc440/readings/hazard-pointers.pdf
 [hyaline reclamation scheme]: https://arxiv.org/pdf/1905.07903.pdf
 [epoch based reclamation]:
   https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-579.pdf
-[tokio]: https://github.com/tokio-rs/tokio

--- a/benches/single_thread.rs
+++ b/benches/single_thread.rs
@@ -48,7 +48,7 @@ criterion_main!(benches);
 
 mod seize_stack {
     use criterion::black_box;
-    use seize::{Collector, Link, Linked};
+    use seize::{Collector, Guard, Link, Linked};
     use std::ptr;
 
     pub struct Stack {

--- a/benches/stack.rs
+++ b/benches/stack.rs
@@ -69,7 +69,7 @@ criterion_group!(benches, treiber_stack);
 criterion_main!(benches);
 
 mod seize_stack {
-    use seize::{reclaim, Collector, Linked};
+    use seize::{reclaim, Collector, Guard, Linked};
     use std::mem::ManuallyDrop;
     use std::ptr;
     use std::sync::atomic::{AtomicPtr, Ordering};

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,0 +1,247 @@
+A quick-start guide for working with `seize`.
+
+# Introduction
+
+Seize tries to stay out of your way as much as possible. It works with raw
+pointers directly instead of creating safe wrapper types that end up being a
+hassle to work with in practice. Below is a step-by-step guide on how to get
+started. We'll be writing a stack that implements concurrent `push` and `pop`
+operations. The details of how the stack works are not directly relevant, the
+guide will instead focus on how Seize works generally.
+
+# Collectors
+
+Seize avoids the use of global state and encourages creating a designated
+_collector_ per data structure. Collectors allow you to allocate, protect, and
+retire objects.
+
+```rust,ignore
+use seize::Collector;
+
+struct Stack<T> {
+    collector: Collector,
+    // ...
+}
+
+impl<T> Stack<T> {
+    pub fn new() -> Self {
+        Self {
+            collector: Collector::new(),
+        }
+    }
+}
+```
+
+# Allocating Objects
+
+Seize requires storing some metadata about the global epoch for each object that
+is allocated. Because of this, objects in a concurrent data structure that may be
+reclaimed must embed the `Link` type or use the `Linked<T>` wrapper provided for
+convenience. See [DST Support](#dst-support) for more details.
+
+You can create a `Link` with the `link` method, or allocate and link a value with
+the `link_boxed` helper:
+
+```rust
+use seize::{reclaim, Collector, Linked};
+use std::mem::ManuallyDrop;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+pub struct Stack<T> {
+    head: AtomicPtr<Linked<Node<T>>>, // <===
+    collector: Collector,
+}
+
+struct Node<T> {
+    next: *mut Linked<Node<T>>, // <===
+    value: ManuallyDrop<T>,
+}
+
+impl<T> Stack<T> {
+    pub fn push(&self, value: T) {
+        let node = self.collector.link_boxed(Node { // <===
+            next: std::ptr::null_mut(),
+            value: ManuallyDrop::new(value),
+        });
+
+        // ...
+    }
+}
+```
+
+# Starting Operations
+
+Before starting an operation that involves loading objects that may eventually be reclaimed,
+you must mark the thread as _active_ by calling the `enter` method.
+
+```rust,ignore
+impl Stack {
+    pub fn push(&self, value: T) {
+        // ...
+
+        let guard = self.collector.enter(); // <===
+
+        // ...
+    }
+}
+```
+
+# Protecting Pointers
+
+`enter` returns a guard that allows you to safely load atomic pointers. Guards are
+the core of safe memory reclamation. Any valid pointer loaded through a guard using the
+`protect` method is guaranteed to stay valid until the guard is dropped, or is retired
+by the current thread. Importantly, if another thread retires an object that you protected,
+the collector knows not to reclaim the object until your guard is dropped.
+
+```rust,ignore
+impl Stack {
+    pub fn push(&self, value: T) {
+        // ...
+
+        let guard = self.collector.enter();
+
+        loop {
+            let head = guard.protect(&self.head, Ordering::Acquire); // <===
+            unsafe { (*node).next = head; }
+
+            if self
+                .head
+                .compare_exchange(head, node, Ordering::Release, Ordering::Relaxed)
+                .is_ok()
+            {
+                break;
+            }
+        }
+
+        // drop(guard);
+    }
+}
+```
+
+Note that the lifetime of a guarded pointer is logically tied to that of the
+guard -- when the guard is dropped the pointer is invalidated -- but a raw
+pointer is returned for convenience. Data structures that return shared references
+to values should ensure that the lifetime of the reference is tied to the lifetime
+of a guard.
+
+# Retiring Objects
+
+Objects that have been removed from a data structure can be safely _retired_
+through the collector. It will be _reclaimed_, or freed, when no threads holds
+a reference to it:
+
+```rust,ignore
+impl<T> Stack<T> {
+    pub fn pop(&self) -> Option<T> {
+        let guard = self.collector.enter(); // <=== mark the thread as active
+
+        loop {
+            let head = guard.protect(&self.head, Ordering::Acquire); // <=== safely load the head
+
+            if head.is_null() {
+                return None;
+            }
+
+            let next = unsafe { (*head).next };
+
+            if self
+                .head
+                .compare_exchange(head, next, Ordering::Release, Ordering::Relaxed)
+                .is_ok()
+            {
+                unsafe {
+                    let data = ptr::read(&(*head).value);
+                    self.collector.retire(head, reclaim::boxed::<Linked<Node<T>>>); // <=== retire
+                    return Some(ManuallyDrop::into_inner(data));
+                }
+            }
+        }
+    }
+}
+```
+
+There are a couple important things to note about retiring an object:
+
+### Retired objects must be logically removed
+
+An object can only be retired if it is _no longer accessible_ to any thread that
+comes after. In the above code example this was ensured by swapping out the node
+before retiring it. Threads that loaded a value _before_ it was retired are
+safe, but threads that come after are not.
+
+Note that concurrent stacks typically suffer from the [ABA problem]. Using `retire`
+after popping a node ensures that the node is only freed _after_ all active threads
+that could have loaded it exit, avoiding any potential ABA.
+
+### Retired objects cannot be accessed by the current thread
+
+Unlike in schemes like EBR, a guard does not protect objects retired by the
+current thread. If no other thread holds a reference to an object it may be
+reclaimed _immediately_. This makes the following code unsound:
+
+```rust,ignore
+let ptr = guard.protect(&node, Ordering::Acquire);
+collector.retire(ptr, |_| {});
+println!("{}", (*ptr).value); // <===== unsound!
+```
+
+Retirement can be delayed until the guard is dropped by calling `defer_retire` on
+the guard, instead of on the collector directly:
+
+```rust,ignore
+let ptr = guard.protect(&node, Ordering::Acquire);
+guard.defer_retire(ptr, |_| {});
+println!("{}", (*ptr).value); // <===== ok!
+drop(guard); // <===== ptr is invalidated
+```
+
+### Custom Reclaimers
+
+You probably noticed that `retire` takes a function as a second parameter. This
+function is known as a _reclaimer_, and is run when the collector decides it is
+safe to free the retired object. Typically you will pass in a function from the
+[`seize::reclaim`](https://docs.rs/seize/latest/seize/reclaim/index.html) module.
+For example, values allocated with `Box` can use `reclaim::boxed`:
+
+```rust,ignore
+use seize::reclaim;
+
+impl<T> Stack<T> {
+    pub fn pop(&self) -> Option<T> {
+        // ...
+        self.collector.retire(head, reclaim::boxed::<Linked<Node<T>>); // <===
+        // ...
+    }
+}
+```
+
+The type annotation there is important. It is **unsound** to pass a reclaimer of
+a different type than the object being retired.
+
+If you need to run custom reclamation code, you can write a custom reclaimer.
+Functions passed to `retire` are called with a type-erased `Link` pointer. This is
+because retired values lose any type information during the reclamation process.
+To extract the underlying value from a link, you can call the `cast` method:
+
+```rust,ignore
+collector.retire(value, |link: *mut Link| unsafe {
+    // safety: the value retired was of type *mut Linked<T>
+    let ptr: *mut Linked<T> = Link::cast(link);
+
+    // safety: the value was allocated with `link_boxed`
+    let value = Box::from_raw(ptr);
+    println!("dropping {}", value);
+    drop(value);
+});
+```
+
+## DST Support
+
+Most reclamation use cases can work with `Linked<T>` and avoid working with
+links directly. However, advanced use cases such as dynamically sized types
+may requie more control over type layout. To support this, seize allows embedding
+a `Link` directly in your type. See the [`AsLink`](https://docs.rs/seize/latest/seize/trait.AsLink.html)
+trait for more details.
+
+[ABA problem]: https://en.wikipedia.org/wiki/ABA_problem

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,17 +1,16 @@
-use crate::raw;
 use crate::tls::Thread;
+use crate::{raw, LocalGuard, OwnedGuard};
 
 use std::cell::UnsafeCell;
-use std::marker::PhantomData;
 use std::num::NonZeroU64;
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::Ordering;
 use std::{fmt, ptr};
 
 /// Fast, efficient, and robust memory reclamation.
 ///
 /// See the [crate documentation](crate) for details.
 pub struct Collector {
-    raw: raw::Collector,
+    pub(crate) raw: raw::Collector,
     unique: *mut u8,
 }
 
@@ -125,15 +124,14 @@ impl Collector {
     /// # unsafe { guard2.defer_retire(value, reclaim::boxed::<Linked<usize>>) };
     /// drop(guard2) // _now_, the thread is marked as inactive
     /// ```
-    pub fn enter(&self) -> Guard<'_> {
-        let thread = Thread::current();
-        unsafe { self.raw.enter(thread) };
+    pub fn enter(&self) -> LocalGuard<'_> {
+        LocalGuard::enter(self)
+    }
 
-        Guard {
-            thread,
-            collector: Some(self),
-            _unsend: PhantomData,
-        }
+    /// Create an owned guard that protects objects for it's
+    /// lifetime, independent of the current thread.
+    pub fn enter_owned(&self) -> OwnedGuard<'_> {
+        OwnedGuard::enter(self)
     }
 
     /// Link a value to the collector.
@@ -198,14 +196,13 @@ impl Collector {
     pub unsafe fn retire<T: AsLink>(&self, ptr: *mut T, reclaim: unsafe fn(*mut Link)) {
         debug_assert!(!ptr.is_null(), "attempted to retire null pointer");
 
-        // note that `add` doesn't actually reclaim the pointer immediately if the
-        // current thread is active, it instead adds it to it's reclamation list,
+        // note that `add` doesn't ever actually reclaim the pointer immediately if
+        // the current thread is active, it instead adds it to it's reclamation list,
         // but we don't guarantee that publicly.
         unsafe { self.raw.add(ptr, reclaim, Thread::current()) }
     }
 
-    /// Returns true if both references point to the same collector.
-    pub fn ptr_eq(this: &Collector, other: &Collector) -> bool {
+    pub(crate) fn ptr_eq(this: &Collector, other: &Collector) -> bool {
         ptr::eq(this.unique, other.unique)
     }
 }
@@ -244,145 +241,6 @@ impl fmt::Debug for Collector {
             .field("batch_size", &self.raw.batch_size)
             .field("epoch_frequency", &self.raw.epoch_frequency)
             .finish()
-    }
-}
-
-/// A guard that keeps the current thread marked as active,
-/// enabling protected loads of atomic pointers.
-///
-/// See [`Collector::enter`] for details.
-pub struct Guard<'a> {
-    collector: Option<&'a Collector>,
-    thread: Thread,
-    // must not be Send or Sync as we are tied to the current threads state in
-    // the collector
-    _unsend: PhantomData<*mut ()>,
-}
-
-impl Guard<'_> {
-    /// Returns a dummy guard.
-    ///
-    /// Calling [`protect`](Guard::protect) on an unprotected guard will
-    /// load the pointer directly, and [`retire`](Guard::defer_retire) will
-    /// reclaim objects immediately.
-    ///
-    /// Unprotected guards are useful when calling guarded functions
-    /// on a data structure that has just been created or is about
-    /// to be destroyed, because you know that no other thread holds
-    /// a reference to it.
-    ///
-    /// # Safety
-    ///
-    /// You must ensure that code used with this guard is sound with
-    /// the unprotected behavior described above.
-    pub const unsafe fn unprotected() -> Guard<'static> {
-        Guard {
-            thread: Thread::EMPTY,
-            collector: None,
-            _unsend: PhantomData,
-        }
-    }
-
-    /// Protects the load of an atomic pointer.
-    ///
-    /// See [the guide](crate#protecting-pointers) for details.
-    #[inline]
-    pub fn protect<T: AsLink>(&self, ptr: &AtomicPtr<T>, ordering: Ordering) -> *mut T {
-        match self.collector {
-            Some(collector) => unsafe { collector.raw.protect(ptr, ordering, self.thread) },
-            // unprotected guard
-            None => ptr.load(ordering),
-        }
-    }
-
-    /// Retires a value, running `reclaim` when no threads hold a reference to it.
-    ///
-    /// This method delays reclamation until the guard is dropped as opposed to
-    /// [`Collector::retire`], which may reclaim objects immediately.
-    ///
-    /// See [the guide](crate#retiring-objects) for details.
-    #[allow(clippy::missing_safety_doc)] // in guide
-    pub unsafe fn defer_retire<T: AsLink>(&self, ptr: *mut T, reclaim: unsafe fn(*mut Link)) {
-        debug_assert!(!ptr.is_null(), "attempted to retire null pointer");
-
-        match self.collector {
-            Some(collector) => unsafe { collector.raw.add(ptr, reclaim, self.thread) },
-            // unprotected guard
-            None => unsafe { (reclaim)(ptr.cast::<Link>()) },
-        }
-    }
-
-    /// Get a reference to the collector this guard we created from.
-    ///
-    /// This method is useful when you need to ensure that all guards
-    /// used with a data structure come from the same collector.
-    ///
-    /// If this is an [`unprotected`](Guard::unprotected) guard
-    /// this method will return `None`.
-    pub fn collector(&self) -> Option<&Collector> {
-        self.collector
-    }
-
-    /// Refreshes the guard.
-    ///
-    /// Refreshing a guard is similar to dropping and immediately
-    /// creating a new guard. The curent thread remains active, but any
-    /// pointers that were previously protected may be reclaimed.
-    ///
-    /// # Safety
-    ///
-    /// This method is not marked as `unsafe`, but will affect
-    /// the validity of pointers returned by [`protect`](Guard::protect),
-    /// similar to dropping a guard. It is intended to be used safely
-    /// by users of concurrent data structures, as references will
-    /// be tied to the guard and this method takes `&mut self`.
-    ///
-    /// If this is an [`unprotected`](Guard::unprotected) guard
-    /// this method will be a no-op.
-    pub fn refresh(&mut self) {
-        match self.collector {
-            None => {}
-            Some(collector) => unsafe { collector.raw.refresh(self.thread) },
-        }
-    }
-
-    /// Flush any retired values in the local batch.
-    ///
-    /// This method flushes any values from the current thread's local
-    /// batch, starting the reclamation process. Note that no memory
-    /// can be reclaimed while this guard is active, but calling `flush`
-    /// may allow memory to be reclaimed more quickly after the guard is
-    /// dropped.
-    ///
-    /// See [`Collector::batch_size`] for details about batching.
-    pub fn flush(&self) {
-        if let Some(collector) = self.collector {
-            unsafe { collector.raw.try_retire_batch(self.thread) }
-        }
-    }
-
-    /// Returns a numeric identifier for the current thread.
-    ///
-    /// Guards rely on thread-local state, including thread IDs. If you already
-    /// have a guard you can use this method to get a cheap identifier for the
-    /// current thread, avoiding TLS overhead. Note that thread IDs may be reused,
-    /// so the value returned is only unique for the lifetime of this thread.
-    pub fn thread_id(&self) -> usize {
-        self.thread.id
-    }
-}
-
-impl Drop for Guard<'_> {
-    fn drop(&mut self) {
-        if let Some(collector) = self.collector {
-            unsafe { collector.raw.leave(self.thread) }
-        }
-    }
-}
-
-impl fmt::Debug for Guard<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Guard").finish()
     }
 }
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,0 +1,273 @@
+use std::fmt;
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+use crate::tls::Thread;
+use crate::{AsLink, Collector, Link};
+
+/// A guard that enables protected loads of atomic pointers.
+pub trait Guard: Clone {
+    /// Protects the load of an atomic pointer.
+    ///
+    /// See [the guide](crate#protecting-pointers) for details.
+    fn protect<T: AsLink>(&self, ptr: &AtomicPtr<T>, ordering: Ordering) -> *mut T;
+
+    /// Retires a value, running `reclaim` when no threads hold a reference to it.
+    ///
+    /// This method delays reclamation until the guard is dropped as opposed to
+    /// [`Collector::retire`], which may reclaim objects immediately.
+    ///
+    /// See [the guide](crate#retiring-objects) for details.
+    unsafe fn defer_retire<T: AsLink>(&self, ptr: *mut T, reclaim: unsafe fn(*mut Link));
+
+    /// Refreshes the guard.
+    ///
+    /// Refreshing a guard is similar to dropping and immediately
+    /// creating a new guard. The curent thread remains active, but any
+    /// pointers that were previously protected may be reclaimed.
+    ///
+    /// # Safety
+    ///
+    /// This method is not marked as `unsafe`, but will affect
+    /// the validity of pointers returned by [`protect`](Guard::protect),
+    /// similar to dropping a guard. It is intended to be used safely
+    /// by users of concurrent data structures, as references will
+    /// be tied to the guard and this method takes `&mut self`.
+    fn refresh(&mut self);
+
+    /// Flush any retired values in the local batch.
+    ///
+    /// This method flushes any values from the current thread's local
+    /// batch, starting the reclamation process. Note that no memory
+    /// can be reclaimed while this guard is active, but calling `flush`
+    /// may allow memory to be reclaimed more quickly after the guard is
+    /// dropped.
+    ///
+    /// See [`Collector::batch_size`] for details about batching.
+    fn flush(&self);
+
+    /// Returns a numeric identifier for the current thread.
+    ///
+    /// Guards rely on thread-local state, including thread IDs. If you already
+    /// have a guard you can use this method to get a cheap identifier for the
+    /// current thread, avoiding TLS overhead. Note that thread IDs may be reused,
+    /// so the value returned is only unique for the lifetime of this thread.
+    fn thread_id(&self) -> usize;
+
+    /// Returns `true` if this guard belongs to the given collector.
+    ///
+    /// This can be used to verify that user-provided guards are valid
+    /// for the expected collector.
+    fn belongs_to(&self, collector: &Collector) -> bool;
+}
+
+/// A guard that keeps the current thread marked as active.
+///
+/// See [`Collector::enter`] for details.
+pub struct LocalGuard<'a> {
+    collector: &'a Collector,
+    thread: Thread,
+    // must not be Send or Sync as we are tied to the current threads state in
+    // the collector
+    _unsend: PhantomData<*mut ()>,
+}
+
+impl LocalGuard<'_> {
+    pub(crate) fn enter(collector: &Collector) -> LocalGuard<'_> {
+        let thread = Thread::current();
+        unsafe { collector.raw.enter(thread) };
+
+        LocalGuard {
+            thread,
+            collector,
+            _unsend: PhantomData,
+        }
+    }
+}
+
+impl Guard for LocalGuard<'_> {
+    /// Protects the load of an atomic pointer.
+    #[inline]
+    fn protect<T: AsLink>(&self, ptr: &AtomicPtr<T>, ordering: Ordering) -> *mut T {
+        unsafe { self.collector.raw.protect(ptr, ordering, self.thread) }
+    }
+
+    /// Retires a value, running `reclaim` when no threads hold a reference to it.
+    unsafe fn defer_retire<T: AsLink>(&self, ptr: *mut T, reclaim: unsafe fn(*mut Link)) {
+        debug_assert!(!ptr.is_null(), "attempted to retire null pointer");
+
+        unsafe { self.collector.raw.add(ptr, reclaim, self.thread) }
+    }
+
+    /// Refreshes the guard.
+    fn refresh(&mut self) {
+        unsafe { self.collector.raw.refresh(self.thread) }
+    }
+
+    /// Flush any retired values in the local batch.
+    fn flush(&self) {
+        unsafe { self.collector.raw.try_retire_batch(self.thread) }
+    }
+
+    /// Returns a numeric identifier for the current thread.
+    fn thread_id(&self) -> usize {
+        self.thread.id
+    }
+
+    /// Returns `true` if this guard belongs to the given collector.
+    fn belongs_to(&self, collector: &Collector) -> bool {
+        Collector::ptr_eq(self.collector, collector)
+    }
+}
+
+impl Clone for LocalGuard<'_> {
+    fn clone(&self) -> Self {
+        // this will just increment the guard reference count
+        unsafe { self.collector.raw.enter(self.thread) };
+
+        LocalGuard {
+            thread: self.thread,
+            collector: self.collector,
+            _unsend: PhantomData,
+        }
+    }
+}
+
+impl Drop for LocalGuard<'_> {
+    fn drop(&mut self) {
+        // this will mark the thread inactive if this is the last active guard
+        // on this thread
+        unsafe { self.collector.raw.leave(self.thread) };
+    }
+}
+
+impl fmt::Debug for LocalGuard<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("LocalGuard").finish()
+    }
+}
+
+/// A guard that protects objects for it's lifetime, independent of the current thread.
+///
+/// See [`Collector::enter_owned`] for details.
+#[derive(Clone)]
+pub struct OwnedGuard<'a>(ManuallyDrop<LocalGuard<'a>>);
+
+// This is sound because an `OwnedGuard` owns its thread
+// slot, so is not tied to any thread-locals.
+//
+// Note: cannot be Sync because retire takes &self and does
+// not synchronize across threads.
+unsafe impl Send for OwnedGuard<'_> {}
+
+impl OwnedGuard<'_> {
+    pub(crate) fn enter(collector: &Collector) -> OwnedGuard<'_> {
+        OwnedGuard(ManuallyDrop::new(LocalGuard {
+            collector,
+            thread: Thread::create(),
+            _unsend: PhantomData,
+        }))
+    }
+}
+
+impl Guard for OwnedGuard<'_> {
+    /// Protects the load of an atomic pointer.
+    #[inline]
+    fn protect<T: AsLink>(&self, ptr: &AtomicPtr<T>, ordering: Ordering) -> *mut T {
+        self.0.protect(ptr, ordering)
+    }
+
+    /// Retires a value, running `reclaim` when no threads hold a reference to it.
+    unsafe fn defer_retire<T: AsLink>(&self, ptr: *mut T, reclaim: unsafe fn(*mut Link)) {
+        // safety: delegation, guaranteed by caller
+        unsafe { self.0.defer_retire(ptr, reclaim) }
+    }
+
+    /// Refreshes the guard.
+    fn refresh(&mut self) {
+        self.0.refresh()
+    }
+
+    /// Flush any retired values in the local batch.
+    fn flush(&self) {
+        self.0.flush()
+    }
+
+    /// Returns a numeric identifier for the current thread.
+    fn thread_id(&self) -> usize {
+        // we can't return the ID of our thread slot because `OwnedGuard`
+        // is `Send` so the ID is not uniquely tied to the current thread.
+        // we also can't return the OS thread ID because it might conflict
+        // with our thread IDs, so we have to get/create the current thread.
+        Thread::current().id
+    }
+
+    /// Returns `true` if this guard belongs to the given collector.
+    fn belongs_to(&self, collector: &Collector) -> bool {
+        self.0.belongs_to(collector)
+    }
+}
+
+impl Drop for OwnedGuard<'_> {
+    fn drop(&mut self) {
+        if unsafe { self.0.collector.raw.leave(self.0.thread) } {
+            // this was the last reference to the guard. we are now inactive
+            // and can free the thread slot
+            self.0.thread.free();
+        }
+    }
+}
+
+/// Returns a dummy guard object.
+///
+/// Calling [`protect`](Guard::protect) on an unprotected guard will
+/// load the pointer directly, and [`retire`](Guard::defer_retire) will
+/// reclaim objects immediately.
+///
+/// Unprotected guards are useful when calling guarded functions
+/// on a data structure that has just been created or is about
+/// to be destroyed, because you know that no other thread holds
+/// a reference to it.
+///
+/// # Safety
+///
+/// You must ensure that code used with this guard is sound with
+/// the unprotected behavior described above.
+pub unsafe fn unprotected() -> UnprotectedGuard {
+    UnprotectedGuard
+}
+
+/// A dummy guard object.
+///
+/// See [`unprotected`] for details.
+#[derive(Clone, Debug)]
+pub struct UnprotectedGuard;
+
+impl Guard for UnprotectedGuard {
+    /// Loads the pointer directly, using the given ordering.
+    fn protect<T: AsLink>(&self, ptr: &AtomicPtr<T>, ordering: Ordering) -> *mut T {
+        ptr.load(ordering)
+    }
+
+    /// Reclaims the pointer immediately.
+    unsafe fn defer_retire<T: AsLink>(&self, ptr: *mut T, reclaim: unsafe fn(*mut Link)) {
+        unsafe { reclaim(ptr.cast::<Link>()) }
+    }
+
+    /// This method is a no-op.
+    fn refresh(&mut self) {}
+
+    /// This method is a no-op.
+    fn flush(&self) {}
+
+    /// Returns a numeric identifier for the current thread.
+    fn thread_id(&self) -> usize {
+        Thread::current().id
+    }
+
+    /// Unprotected guards aren't tied to a specific collector, so this always returns `true`.
+    fn belongs_to(&self, _collector: &Collector) -> bool {
+        true
+    }
+}

--- a/src/guide.rs
+++ b/src/guide.rs
@@ -1,0 +1,1 @@
+#![doc = include_str!("../docs/GUIDE.md")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,12 @@
 #![doc = include_str!("../README.md")]
 
 mod collector;
+mod guard;
 mod raw;
 mod tls;
 mod utils;
 
 pub mod reclaim;
 
-pub use collector::{AsLink, Collector, Guard, Link, Linked};
+pub use collector::{AsLink, Collector, Link, Linked};
+pub use guard::{unprotected, Guard, LocalGuard, OwnedGuard, UnprotectedGuard};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod raw;
 mod tls;
 mod utils;
 
+pub mod guide;
 pub mod reclaim;
 
 pub use collector::{AsLink, Collector, Link, Linked};

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -71,7 +71,7 @@ impl Collector {
     //
     // # Safety
     //
-    // `thread` must be the current thread.
+    // This method is not safe to call concurrently with the same `thread`.
     pub unsafe fn enter(&self, thread: Thread) {
         let reservation = self.reservations.load(thread);
 
@@ -97,7 +97,7 @@ impl Collector {
     //
     // # Safety
     //
-    // `thread` must be the current thread.
+    // This method is not safe to call concurrently with the same `thread`.
     #[inline]
     pub unsafe fn protect<T>(
         &self,
@@ -157,7 +157,7 @@ impl Collector {
     //
     // # Safety
     //
-    // `thread` must be the current thread.
+    // This method is not safe to call concurrently with the same `thread`.
     pub unsafe fn leave(&self, thread: Thread) -> bool {
         let reservation = self.reservations.load(thread);
 
@@ -187,7 +187,8 @@ impl Collector {
     //
     // # Safety
     //
-    // `thread` must be the current thread.
+    // This method is not safe to call concurrently with the same `thread`. Any
+    // previously protected values may be invalidated.
     pub unsafe fn refresh(&self, thread: Thread) {
         let reservation = self.reservations.load(thread);
         let guards = reservation.guards.get();
@@ -211,7 +212,8 @@ impl Collector {
     //
     // # Safety
     //
-    // `ptr` is a valid pointer, and `thread` must be the current thread.
+    // `ptr` must be a valid pointer that is no longer accessible to any inactive threads.
+    // This method is not safe to call concurrently with the same `thread`.
     pub unsafe fn add<T>(&self, ptr: *mut T, reclaim: unsafe fn(*mut Link), thread: Thread)
     where
         T: AsLink,
@@ -261,7 +263,7 @@ impl Collector {
     //
     // # Safety
     //
-    // `thread` must be the current thread.
+    // This method is not safe to call concurrently with the same `thread`.
     pub unsafe fn try_retire_batch(&self, thread: Thread) {
         let local_batch = self
             .batches
@@ -278,7 +280,7 @@ impl Collector {
     //
     // # Safety
     //
-    // `thread` must be the current thread.
+    // This method is not safe to call concurrently with the same `thread`.
     pub unsafe fn try_retire(&self, local_batch: &mut LocalBatch, thread: Thread) {
         // establish a total order between the retirement of nodes in this batch and stores
         // marking a thread as active (or active in an epoch):

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -293,6 +293,7 @@ fn delayed_retire() {
 
     for object in objects {
         unsafe { guard.defer_retire(object, reclaim::boxed::<Linked<DropTrack>>) }
+        guard.flush();
     }
 
     assert_eq!(dropped.load(Ordering::Relaxed), 0);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -389,22 +389,12 @@ fn reentrant() {
 }
 
 #[test]
-fn collector_eq() {
+fn belongs_to() {
     let a = Collector::new();
     let b = Collector::new();
-    let unprotected = unsafe { Guard::unprotected() };
 
-    assert!(Collector::ptr_eq(
-        a.enter().collector().unwrap(),
-        a.enter().collector().unwrap()
-    ));
-    assert!(Collector::ptr_eq(
-        a.enter().collector().unwrap(),
-        a.enter().collector().unwrap()
-    ));
-    assert!(!Collector::ptr_eq(
-        a.enter().collector().unwrap(),
-        b.enter().collector().unwrap()
-    ));
-    assert!(unprotected.collector().is_none());
+    assert!(a.enter().belongs_to(&a));
+    assert!(!a.enter().belongs_to(&b));
+    assert!(b.enter().belongs_to(&b));
+    assert!(!b.enter().belongs_to(&a));
 }


### PR DESCRIPTION
Reworks `Guard` to be a trait implemented by `LocalGuard`, `UnprotectedGuard`, and a new `OwnedGuard` type that implements `Send` and `Sync`. Owned guards reserve a thread slot for their lifetime instead of being tied to the current thread. They also use a `Mutex` to protect their local batch which is required to implement `Sync` soundly (which is needed for e.g. `Send` iterators), despite it being unlikely to access a guard concurrently. This makes them slightly more expensive to use than local guards.

This also removes `Collector::ptr_eq` and replaces it with `Guard::belongs_to`.

Implements https://github.com/ibraheemdev/seize/issues/20.