### PR TITLE
Fix Recursive Calls To `retire`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_transmute_annotations)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -263,11 +263,10 @@ impl Collector {
         // to the node through this pointer.
         let node = UnsafeCell::raw_get(ptr.cast::<UnsafeCell<Node>>());
 
+        // safety: the node and batch are both valid, and we do not hold a mutable
+        // reference across the call to try_retire
         unsafe {
             // keep track of the oldest node in the batch
-            //
-            // safety: the node and batch are both valid, and we do not hold a mutable
-            // reference across the call to try_retire
             let birth_epoch = (*node).birth_epoch;
             (*batch).min_epoch = (*batch).min_epoch.min(birth_epoch);
 
@@ -498,7 +497,7 @@ impl Collector {
             // safety: the reference count is 0, meaning that either no threads were active,
             // or they have all already decremented the reference count
             //
-            // addtionally, the local batch has been reset, and we are not holding on to any mutable
+            // additionally, the local batch has been reset and we are not holding on to any mutable
             // pointers, so any recursive calls to retire during reclamation are valid
             unsafe { Collector::free_batch(batch) }
             return;

--- a/src/tls/thread_id.rs
+++ b/src/tls/thread_id.rs
@@ -8,7 +8,6 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::sync::{Mutex, OnceLock};
-use std::usize;
 
 /// Thread ID manager which allocates thread IDs. It attempts to aggressively
 /// reuse thread IDs where possible to avoid cases where a ThreadLocal grows

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,12 +35,6 @@ pub struct CachePadded<T> {
     pub value: T,
 }
 
-impl<T> CachePadded<T> {
-    pub fn new(value: T) -> Self {
-        Self { value }
-    }
-}
-
 impl<T> std::ops::Deref for CachePadded<T> {
     type Target = T;
 


### PR DESCRIPTION
`retire` is currently unsound if the reclaimer recursively access the collector. We need to reset the batch and drop any mutable references before calling the reclaimer.