### PR TITLE
Allow windows-sys up to 0.61, and use cargo-minimal-versions to validate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,24 @@ jobs:
         run: cargo generate-lockfile
       - name: cargo test
         run: cargo test --locked --all-features --all-targets
+  minimal-versions:
+    # cargo-minimal-versions checks that the crate works with the minimum versions of its
+    # dependencies.
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} / stable / minimal-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: cargo install cargo-minimal-versions
+        uses: taiki-e/install-action@cargo-minimal-versions
+      - name: cargo minimal-versions test
+        run: cargo minimal-versions test --all-features --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.72.0"
 libc = { version = "0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_System_Threading"], optional = true }
+windows-sys = { version = ">=0.59, <=0.61", features = ["Win32_System_Threading"], optional = true }
 
 [features]
 default = ["fast-barrier"]
@@ -23,7 +23,7 @@ default = ["fast-barrier"]
 fast-barrier = ["windows-sys", "libc"]
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = "0.3.6"
 crossbeam-epoch = "0.9.8"
 haphazard = { git = "https://github.com/jonhoo/haphazard", rev = "e0e18f60f78652a63aba235be854f87d106c1a1b" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.72.0"
 libc = { version = "0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = ">=0.59, <=0.61", features = ["Win32_System_Threading"], optional = true }
+windows-sys = { version = ">=0.52, <=0.61", features = ["Win32_System_Threading"], optional = true }
 
 [features]
 default = ["fast-barrier"]


### PR DESCRIPTION
`windows-sys` didn't make any breaking changes in 0.60 or 0.61 that affect `seize`, so permit all versions from 0.59-0.61 to be used.

This change also adds tests via `cargo-minimal-versions` to ensure that the crate still works correctly with minimal versions of its dependencies.

Also had to bump `criterion` to 0.3.6 from 0.3.5, otherwise minimal-versions would pull in two versions of `winapi`, which then causes issues.