### PR TITLE
Use a published version of haphazard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ fast-barrier = ["windows-sys", "libc"]
 [dev-dependencies]
 criterion = "0.3.5"
 crossbeam-epoch = "0.9.8"
-haphazard = { git = "https://github.com/jonhoo/haphazard", rev = "e0e18f60f78652a63aba235be854f87d106c1a1b" }
+haphazard = "0.1.8"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(seize_asan)'] }


### PR DESCRIPTION
[Commit `e0e18f60f78652a63aba235be854f87d106c1a1b` of `haphazard`](https://github.com/jonhoo/haphazard/commit/e0e18f60f78652a63aba235be854f87d106c1a1b) was included in the 0.1.5 release, so switch to the published crate instead of using a Git dependency.