### PR TITLE
Bump criterion to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["fast-barrier"]
 fast-barrier = ["windows-sys", "libc"]
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = "0.7.0"
 crossbeam-epoch = "0.9.8"
 haphazard = { git = "https://github.com/jonhoo/haphazard", rev = "e0e18f60f78652a63aba235be854f87d106c1a1b" }
 


### PR DESCRIPTION
`criterion` has had multiple breaking change versions, but these don't affect the usage in `seize`, so update to the latest version.

This has the advantage of removing `winapi` as an indirect dev-dependency, and `windows-sys` 0.48 when combined with #43.